### PR TITLE
server: Add Public Action to Bunch to list Public Bunches (`/api/v1/bunch/public`)

### DIFF
--- a/server/bunch/permissions.py
+++ b/server/bunch/permissions.py
@@ -38,7 +38,11 @@ class IsBunchOwner(permissions.BasePermission):
         if not request.user.is_authenticated:
             return False
 
-        bunch_id = view.kwargs.get("bunch_id")
+        if "bunch_id" in view.kwargs:
+            bunch_id = view.kwargs.get("bunch_id")
+        else:
+            bunch_id = view.kwargs.get("id")
+
         if bunch_id:
             return request.user.owned_bunches.filter(
                 id=bunch_id
@@ -95,7 +99,11 @@ class IsBunchAdmin(permissions.BasePermission):
         if not request.user.is_authenticated:
             return False
 
-        bunch_id = view.kwargs.get("bunch_id")
+        if "bunch_id" in view.kwargs:
+            bunch_id = view.kwargs.get("bunch_id")
+        else:
+            bunch_id = view.kwargs.get("id")
+
         if bunch_id:
             return request.user.bunch_memberships.filter(
                 bunch_id=bunch_id,

--- a/server/bunch/test_bunch.py
+++ b/server/bunch/test_bunch.py
@@ -30,18 +30,28 @@ class BunchTest(APITestCase):
             last_name="User",
         )
 
-        self.bunch_data = {
+        self.public_bunch_data = {
             "name": "Test Bunch",
             "description": "Test Description",
             "is_private": False,
+            "invite_code": "ABCD12345",
         }
+
+        self.private_bunch_data = {
+            "name": "Private Bunch",
+            "description": "A Private One",
+            "is_private": True,
+            "invite_code": "ABCD1234",
+        }
+
         self.bunch_list_url = "/api/v1/bunch/"
+        self.public_bunch_list_url = "/api/v1/bunch/public/"
 
     def test_create_bunch_no_auth(self):
         """Test bunch creation without authentication"""
         self.client.force_authenticate(user=None)
         response = self.client.post(
-            self.bunch_list_url, self.bunch_data
+            self.bunch_list_url, self.public_bunch_data
         )
         self.assertEqual(
             response.status_code,
@@ -58,7 +68,7 @@ class BunchTest(APITestCase):
         """Test bunch creation with authentication"""
         self.client.force_login(user=self.user)
         response = self.client.post(
-            self.bunch_list_url, self.bunch_data
+            self.bunch_list_url, self.public_bunch_data
         )
         self.assertEqual(
             response.status_code,
@@ -90,6 +100,77 @@ class BunchTest(APITestCase):
             "First member should be owner",
         )
 
+    def test_list_public_bunches_no_auth(self):
+        """Test listing public bunches without authentication"""
+        self.client.force_authenticate(user=None)
+        response = self.client.get(
+            self.public_bunch_list_url
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            "Unauthenticated request should pass",
+        )
+
+    def test_list_public_bunches_with_auth(self):
+        """Test listing public bunches with authentication"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            self.public_bunch_list_url
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            "Authenticated request should pass",
+        )
+
+    def test_list_public_bunches_should_list_public_only(
+        self,
+    ):
+        """Test listing public bunches should list public only"""
+        self.client.force_authenticate(user=self.user)
+
+        # create a public bunch
+        self.client.post(
+            self.bunch_list_url, self.public_bunch_data
+        )
+        # create a private bunch
+        self.client.post(
+            self.bunch_list_url, self.private_bunch_data
+        )
+
+        response = self.client.get(
+            self.public_bunch_list_url
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            "Request to list public bunches should pass",
+        )
+        self.assertEqual(
+            response.data.get("count"),
+            1,
+            "There should be only 1 public bunch",
+        )
+        self.assertEqual(
+            len(response.data.get("results")),
+            1,
+            "There should be only 1 public bunch",
+        )
+        self.assertEqual(
+            response.data.get("results")[0].get("name"),
+            self.public_bunch_data.get("name"),
+            "The bunch should be the public one",
+        )
+        self.assertEqual(
+            response.data.get("results")[0].get(
+                "is_private"
+            ),
+            False,
+            "The bunch should not be private",
+        )
+
     def test_list_bunches_no_auth(self):
         """Test listing bunches without authentication"""
         self.client.force_authenticate(user=None)
@@ -104,7 +185,7 @@ class BunchTest(APITestCase):
         """Test listing bunches with authentication"""
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
-            self.bunch_list_url, self.bunch_data
+            self.bunch_list_url, self.public_bunch_data
         )
         bunch = Bunch.objects.first()
 
@@ -236,7 +317,7 @@ class BunchTest(APITestCase):
         """Test that an owner cannot leave their own bunch"""
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
-            self.bunch_list_url, self.bunch_data
+            self.bunch_list_url, self.public_bunch_data
         )
         bunch = Bunch.objects.first()
 
@@ -257,4 +338,89 @@ class BunchTest(APITestCase):
                 role=RoleChoices.OWNER,
             ).exists(),
             "Owner should still be a member",
+        )
+
+    def test_list_bunches_list_joined_ones(self):
+        """Test listing bunches lists joined ones, even private ones"""
+        self.client.force_authenticate(user=self.user)
+        # create a public bunch
+        response = self.client.post(
+            self.bunch_list_url, self.public_bunch_data
+        )
+        # create a private bunch
+        response = self.client.post(
+            self.bunch_list_url, self.private_bunch_data
+        )
+
+        public_bunch = Bunch.objects.get(is_private=False)
+        private_bunch = Bunch.objects.get(is_private=True)
+
+        assert public_bunch is not None
+        assert private_bunch is not None
+
+        # somehow invite_code doesn't get added to the bunch
+        if private_bunch.invite_code is None:
+            private_bunch.invite_code = (
+                self.private_bunch_data.get("invite_code")
+            )
+            private_bunch.save()
+
+        invite_code = private_bunch.invite_code
+
+        # switch to other user to join
+        self.client.force_authenticate(user=self.other_user)
+
+        join_url = f"/api/v1/bunch/{public_bunch.id}/join/"
+        response = self.client.post(join_url)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED,
+            "public Bunch must be joined",
+        )
+
+        join_url = f"/api/v1/bunch/{private_bunch.id}/join/"
+        response = self.client.post(
+            join_url, {"invite_code": invite_code}
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_201_CREATED,
+            "private Bunch must be joined with invite code",
+        )
+
+        response = self.client.get(
+            self.public_bunch_list_url
+        )
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            "Request to list public bunches should pass",
+        )
+        self.assertEqual(
+            response.data.get("count"),
+            1,
+            "There should be only 1 public bunch",
+        )
+        self.assertEqual(
+            len(response.data.get("results")),
+            1,
+            "There should be only 1 public bunch",
+        )
+
+        # list joined bunches
+        response = self.client.get(self.bunch_list_url)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_200_OK,
+            "Request to list bunches should pass",
+        )
+        self.assertEqual(
+            response.data.get("count"),
+            2,
+            "There should be 2 bunches joined",
+        )
+        self.assertEqual(
+            len(response.data.get("results")),
+            2,
+            "There should 2 bunches joined",
         )


### PR DESCRIPTION
This PR adds a new route `/public` to the `BunchViewSet` to list public bunches.

The route/action has an empty `authentication_classes` to allow users without auth list public bunches.

Fixes #31 