### PR TITLE
Use supabase `.get_claims()` instead of `.get_user()` in an attempt to make auth checks faster

### DIFF
--- a/server/orchard/authentication.py
+++ b/server/orchard/authentication.py
@@ -81,16 +81,16 @@ class SupabaseJWTAuthentication(authentication.BaseAuthentication):
 
         supabase = SupabaseService()
         try:
-            token_user = supabase.get_user(token)
+            token_claims = supabase.get_claims(token)
         except AuthError as e:
             logger.debug(f"Token error: {e}")
             raise exceptions.AuthenticationFailed("Token error")
 
-        if not token_user:
+        if not token_claims:
             raise exceptions.AuthenticationFailed("Token user not found")
 
-        user_id = token_user.user.id
-        email = token_user.user.email
+        user_id = token_claims.get("claims").get("sub")
+        email = token_claims.get("claims").get("email")
 
         logger.debug(f"User ID: {user_id}")
         logger.debug(f"Email: {email}")

--- a/server/orchard/services.py
+++ b/server/orchard/services.py
@@ -2,6 +2,7 @@ import logging
 
 from django.conf import settings
 from supabase import Client, create_client
+from supabase_auth import ClaimsResponse
 from supabase_auth.types import (
     AdminUserAttributes,
     UserAttributes,
@@ -70,6 +71,10 @@ class SupabaseService:
     def get_user(self, jwt: str | None = None) -> UserResponse | None:
         """Get the current user's data."""
         return self.supabase.auth.get_user(jwt)
+
+    def get_claims(self, jwt: str | None = None) -> ClaimsResponse | None:
+        """Get the current user's claims."""
+        return self.supabase.auth.get_claims(jwt)
 
     def update_user(self, data: UserAttributes):
         """Update a user's data."""

--- a/server/users/views.py
+++ b/server/users/views.py
@@ -62,7 +62,7 @@ class UserViewSet(viewsets.ModelViewSet):
         data = request.data
         logger.debug(f"Onboarding payload: {data}")
 
-        metadata = request.supabase_user.user.user_metadata.copy()
+        metadata = request.supabase_user_metadata.copy()
         logger.debug(f"Current user metadata: {metadata}")
         metadata["onboarded"] = True
 


### PR DESCRIPTION
not fully tested, onboarding might be broken since user_metadata was set in auth middleware